### PR TITLE
fix: thumbnail setting error for reserved streams

### DIFF
--- a/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/LiveStreamingDetails.cs
+++ b/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/LiveStreamingDetails.cs
@@ -7,8 +7,8 @@ namespace Mochineko.YouTubeLiveStreamingClient.Responses
     [JsonObject]
     public sealed class LiveStreamingDetails
     {
-        [JsonProperty("actualStartTime"), JsonRequired]
-        public DateTime ActualStartTime { get; private set; }
+        [JsonProperty("actualStartTime")]
+        public DateTime? ActualStartTime { get; private set; }
 
         [JsonProperty("scheduledStartTime")]
         public DateTime? ScheduledStartTime { get; private set; }

--- a/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/VideoThumbnails.cs
+++ b/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/VideoThumbnails.cs
@@ -19,6 +19,6 @@ namespace Mochineko.YouTubeLiveStreamingClient.Responses
         public VideoThumbnail Standard { get; private set; } = new();
         
         [JsonProperty("maxres")]
-        public VideoThumbnail Maxres { get; private set; } = new();
+        public VideoThumbnail? Maxres { get; private set; }
     }
 }

--- a/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/VideoThumbnails.cs
+++ b/Assets/Mochineko/YouTubeLiveStreamingClient/Responses/VideoThumbnails.cs
@@ -18,7 +18,7 @@ namespace Mochineko.YouTubeLiveStreamingClient.Responses
         [JsonProperty("standard"), JsonRequired]
         public VideoThumbnail Standard { get; private set; } = new();
         
-        [JsonProperty("maxres"), JsonRequired]
+        [JsonProperty("maxres")]
         public VideoThumbnail Maxres { get; private set; } = new();
     }
 }


### PR DESCRIPTION
# エラーが起きる状況について
* youtubeの予約配信 かつ サムネイルを設定した場合

# エラー内容
実行時にエラー1が出ています。

```json
[YouTubeLiveStreamingClient] Failed to get live chat ID because -> Failed to deserialize json to dictionary because -> Failed to deserialize Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse from JSON because of Newtonsoft.Json.JsonSerializationException: Required property 'maxres' not found in JSON. Path 'items[0].snippet.thumbnails', line 35, position 9.
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EndProcessProperty (System.Object newObject, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, System.Int32 initialDepth, Newtonsoft.Json.Serialization.JsonProperty property, Newtonsoft.Json.Serialization.JsonSerializerInternalReader+PropertyPresence presence, System.Boolean setDefaultValue) [0x00175] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject (System.Object newObject, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty member, System.String id) [0x002f5] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x00161] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x0006d] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue (Newtonsoft.Json.Serialization.JsonProperty property, Newtonsoft.Json.JsonConverter propertyConverter, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, Newtonsoft.Json.JsonReader reader, System.Object target) [0x00065] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject (System.Object newObject, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty member, System.String id) [0x00280] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x00161] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x0006d] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue (Newtonsoft.Json.Serialization.JsonProperty property, Newtonsoft.Json.JsonConverter propertyConverter, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, Newtonsoft.Json.JsonReader reader, System.Object target) [0x00065] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject (System.Object newObject, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty member, System.String id) [0x00280] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x00161] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x0006d] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList (System.Collections.IList list, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonArrayContract contract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, System.String id) [0x00173] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, System.Object existingValue, System.String id) [0x001c6] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x0007f] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue (Newtonsoft.Json.Serialization.JsonProperty property, Newtonsoft.Json.JsonConverter propertyConverter, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, Newtonsoft.Json.JsonReader reader, System.Object target) [0x00065] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject (System.Object newObject, Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty member, System.String id) [0x00280] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x00161] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) [0x0006d] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize (Newtonsoft.Json.JsonReader reader, System.Type objectType, System.Boolean checkAdditionalContent) [0x000db] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.JsonSerializer.DeserializeInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType) [0x00054] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.JsonSerializer.Deserialize (Newtonsoft.Json.JsonReader reader, System.Type objectType) [0x00000] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.JsonConvert.DeserializeObject (System.String value, System.Type type, Newtonsoft.Json.JsonSerializerSettings settings) [0x0002d] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Newtonsoft.Json.JsonConvert.DeserializeObject[T] (System.String value, Newtonsoft.Json.JsonSerializerSettings settings) [0x00000] in <761cf2a144514d2291a678c334d49e9b>:0 
  at Mochineko.Relent.Extensions.NewtonsoftJson.RelentJsonSerializer.Deserialize[T] (System.String json, Newtonsoft.Json.JsonSerializerSettings settings) [0x00014] in .\Library\PackageCache\com.mochineko.relent.extensions.newtonsoft-json@5fd8738791\RelentJsonSerializer.cs:68 .
, JSON:{
  "kind": "youtube#videoListResponse",
  "etag": "2oGZH1E2Lo6a-B3CWEdit7inrOk",
  "items": [
    {
      "kind": "youtube#video",
      "etag": "9Iy4R_3U9MHsUJVA0DzguHKgLLc",
      "id": "0mbOX8q_2lY",
      "snippet": {
        "publishedAt": "2023-07-22T09:21:28Z",
        "channelId": "UCDXsI9cRoUeiK69ydatgHZQ",
        "title": "ミラ 配信 α Test 7/22",
        "description": "",
        "thumbnails": {
          "default": {
            "url": "https://i.ytimg.com/vi/0mbOX8q_2lY/default_live.jpg",
            "width": 120,
            "height": 90
          },
          "medium": {
            "url": "https://i.ytimg.com/vi/0mbOX8q_2lY/mqdefault_live.jpg",
            "width": 320,
            "height": 180
          },
          "high": {
            "url": "https://i.ytimg.com/vi/0mbOX8q_2lY/hqdefault_live.jpg",
            "width": 480,
            "height": 360
          },
          "standard": {
            "url": "https://i.ytimg.com/vi/0mbOX8q_2lY/sddefault_live.jpg",
            "width": 640,
            "height": 480
          }
        },
        "channelTitle": "MidraLab",
        "categoryId": "24",
        "liveBroadcastContent": "upcoming",
        "localized": {
          "title": "ミラ 配信 α Test 7/22",
          "description": ""
        }
      },
      "liveStreamingDetails": {
        "scheduledStartTime": "2023-07-22T11:00:00Z",
        "activeLiveChatId": "Cg0KCzBtYk9YOHFfMmxZKicKGFVDRFhzSTljUm9VZWlLNjl5ZGF0Z0haURILMG1iT1g4cV8ybFk"
      }
    }
  ],
  "pageInfo": {
    "totalResults": 1,
    "resultsPerPage": 1
  }
}
.

UnityEngine.Debug:LogError (object)
Mochineko.YouTubeLiveStreamingClient.LiveChatMessagesCollector/<GetLiveChatIDAsync>d__23:MoveNext () (at Assets/Mochineko/YouTubeLiveStreamingClient/LiveChatMessagesCollector.cs:224)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1<Mochineko.YouTubeLiveStreamingClient.LiveChatMessagesCollector/<GetLiveChatIDAsync>d__23>:Run () (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:189)
Cysharp.Threading.Tasks.AwaiterActions:Continuation (object) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1<Mochineko.Relent.UncertainResult.IUncertainResult`1<Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse>>:TrySetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.YouTubeLiveStreamingClient.VideosAPI/<GetVideoInformationAsync>d__1, Mochineko.Relent.UncertainResult.IUncertainResult`1<Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse>>:SetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:328)
Mochineko.YouTubeLiveStreamingClient.VideosAPI/<GetVideoInformationAsync>d__1:MoveNext () (at Assets/Mochineko/YouTubeLiveStreamingClient/VideosAPI.cs:150)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.YouTubeLiveStreamingClient.VideosAPI/<GetVideoInformationAsync>d__1, Mochineko.Relent.UncertainResult.IUncertainResult`1<Mochineko.YouTubeLiveStreamingClient.Responses.VideosAPIResponse>>:Run () (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation (object) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1<Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:TrySetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.Relent.UncertainResult.UncertainAsyncCatchFailurePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.Exception>, Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:SetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:328)
Mochineko.Relent.UncertainResult.UncertainAsyncCatchFailurePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.Exception>:MoveNext () (at ./Library/PackageCache/com.mochineko.relent@5fd8738791/UncertainResult/UncertainAsyncCatchFailurePolicy.cs:61)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.Relent.UncertainResult.UncertainAsyncCatchFailurePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.Exception>, Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:Run () (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation (object) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1<Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:TrySetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.Relent.UncertainResult.UncertainAsyncCatchRetryablePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.OperationCanceledException>, Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:SetResult (Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>) (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/CompilerServices/StateMachineRunner.cs:328)
Mochineko.Relent.UncertainResult.UncertainAsyncCatchRetryablePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.OperationCanceledException>:MoveNext () (at ./Library/PackageCache/com.mochineko.relent@5fd8738791/UncertainResult/UncertainAsyncCatchRetryablePolicy.cs:61)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2<Mochineko.Relent.UncertainResult.UncertainAsyncCatchRetryablePolicy`2/<ExecuteAsync>d__3<System.Net.Http.HttpResponseMessage, System.OperationCanceledException>, Mochineko.Relent.UncertainResult.IUncertainResult`1<System.Net.Http.HttpResponseMessage>>:Run () (at ./Library/PackageCache/com.cysharp.unitask@2.3.3/Runtime/Compile<message truncated>
```

# 修正内容
* 配信時間は予約配信では、設定されていない可能性があるため必須プロパティから変更しました
* サムネイルを設定されている場合、取得時にエラーが出ていたため必須プロパティから変更しました